### PR TITLE
Drop 3.4, fix 3.8 in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,6 @@ jobs:
         working-directory: library
         run: |
           python -m pip install coveralls
-          coveralls
+          coveralls --service=github
         if: ${{ matrix.python == '3.8' }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [2.7, 3.4, 3.5, 3.7, 3.8]
+        python: [2.7, 3.5, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/library/tox.ini
+++ b/library/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,37},qa
+envlist = py{27,35,37,38},qa
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
test.yml was failing with:

Version 3.4 was not found in the local cache
Error: Version 3.4 with arch x64 not found
The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json