### PR TITLE
Fix misleading examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,11 @@ lights.set_pixel(2, 0, 0, 255)  # Pixel 3 to Blue
 ```
 
 Pixels are zero-indexed and accept Red, Green and Blue colour values from 0 to 255.
+
+To set the lights, after the colours were set as wanted, use the `show` method:
+
+```python
+lights.show()
+```
+
+Without the `show` method, only the internal data is updated, the lights changes only after this function call.

--- a/library/README.md
+++ b/library/README.md
@@ -50,6 +50,14 @@ lights.set_pixel(2, 0, 0, 255)  # Pixel 3 to Blue
 
 Pixels are zero-indexed and accept Red, Green and Blue colour values from 0 to 255.
 
+To set the lights, after the colours were set as wanted, use the `show` method:
+
+```python
+lights.show()
+```
+
+Without the `show` method, only the internal data is updated, the lights changes only after this function call.
+
 # Changelog
 
 0.0.3


### PR DESCRIPTION
According to the original example, calling the function
`lights.set_pixel(...)` should change the light of the LED in the given
position. However, this function only sets the internal buffer, and to
actually change the values of the LEDs a call to `lights.show()` should
be done.

The commit updates the documentation in the README files (both README.md
and library/README.md) with more precise description.

The commit fixes #6.